### PR TITLE
Reorganize code for stopping conditions.

### DIFF
--- a/src/decision_tree.cpp
+++ b/src/decision_tree.cpp
@@ -318,42 +318,40 @@ void DecisionTree::fit_(TreeNode* node)
     LabelCounter label_counter = LabelCounter(dataframe.col(-1));
     double proportion = label_counter.get_values()->max()/label_counter.size();
     if ( label_counter.size()==1 ) {
-        ;  // Prune if there is only one class left.
+        return;  // Prune if there is only one class left.
     } else if ( dataframe.length()<2 ) {
-        ;  // Prune if there is not enough data to split.
+        return;  // Prune if there is not enough data to split.
     } else if ( (this->max_height_!=-1) and (node->getDepth()+1>=this->max_height_) ) { 
-        ;  // Prune if adding children would exceed max depth:
+        return;  // Prune if adding children would exceed max depth:
     } else if ( (this->max_leaves_!=-1) and (this->num_leaves_+1>=this->max_leaves_) ) { 
-        ;  // Prune if adding children would exceed max leaves:
+        return;  // Prune if adding children would exceed max leaves:
     } else if ( (this->min_obs_!=-1) and (dataframe.length()<=this->min_obs_) ) {
-        ;  // Prune if node is below minimum leave size.
+        return;  // Prune if node is below minimum leave size.
     } else if ( (this->max_prop_!=-1) and (  proportion>=this->max_prop_) ) {
-        ;  // Prune if proportion of majority label is above threshold.
-    } else {
-        // Find best split at this node:
-        std::pair<int,double> split = this->findBestSplit(node);
-        int split_feature = split.first;
-        double split_threshold = split.second;
-        node->setSplitFeature(split_feature);
-        node->setSplitThreshold(split_threshold);
-        // Apply best split at this node:
-        this->num_leaves_ += 1;  // Each split causes net addition of 1 leaf.
-        std::vector<DataFrame*> dataset_splits = dataframe.split(split_feature,split_threshold,true);  // equal_goes_left=true.
-        DataFrame *left_data = dataset_splits[0];
-        DataFrame *right_data = dataset_splits[1];
-        // If split produces two non-empty dataframes, recurse to (new) children:
-        if ( (left_data->length()>0) and (right_data->length()>0) ) {
-            TreeNode *left_child = new TreeNode(*left_data);
-            TreeNode *right_child = new TreeNode(*right_data);
-            node->setLeft(left_child);
-            node->setRight(right_child);
-            // Recurse to (new) children:
-            this->fit_(left_child);
-            this->fit_(right_child);
-        } else {
-            ;  // Prune if best split does not actually split the dataset.
-        }
+        return;  // Prune if proportion of majority label is above threshold.
     }
+    // Find best split at this node:
+    std::pair<int,double> split = this->findBestSplit(node);
+    int split_feature = split.first;
+    double split_threshold = split.second;
+    node->setSplitFeature(split_feature);
+    node->setSplitThreshold(split_threshold);
+    // Calculate results of best split:
+    std::vector<DataFrame*> dataset_splits = dataframe.split(split_feature,split_threshold,true);  // equal_goes_left=true.
+    DataFrame *left_data = dataset_splits[0];
+    DataFrame *right_data = dataset_splits[1];
+    if ( (left_data->length()==0) or (right_data->length()==0) ) {
+        return;  // Prune if best split does not actually split the dataset.
+    }
+    // If split produces two non-empty dataframes, recurse to (new) children:
+    this->num_leaves_ += 1;  // Each split causes net addition of 1 leaf.
+    TreeNode *left_child = new TreeNode(*left_data);
+    TreeNode *right_child = new TreeNode(*right_data);
+    node->setLeft(left_child);
+    node->setRight(right_child);
+    // Recurse to (new) children:
+    this->fit_(left_child);
+    this->fit_(right_child);
 }
 
 void DecisionTree::fit()


### PR DESCRIPTION
Mostly updated for clarity (using "return" keyword when a pruning condition is met, rather than just skipping over the splitting code).

But also fixed a minor bug: The previous code incremented the leaf counter too soon (i.e. there was a possibility it would get incremented even if we ended up pruning because one side of the split had zero observations).