### PR TITLE
Implement bootstrapping

### DIFF
--- a/src/datasets.cpp
+++ b/src/datasets.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <iomanip>
 #include <vector>
+#include <random>
 
 
 /*
@@ -495,6 +496,38 @@ DataFrame DataFrame::copy() const
 {
     /** Returns a copy of the DataFrame. */
     DataFrame *new_frame = new DataFrame(this->matrix());
+    return *new_frame;
+}
+
+DataFrame DataFrame::sample(int nrow, int seed) const{
+    // Set random seed for reproducibility if specified
+    if (seed == -1){
+        // obtain a random number from hardware
+        std::random_device rd;
+        seed = rd();
+    }else{
+        assert(seed >= 0);
+    }
+    // number of rows to pull
+    if (nrow == -1){
+        nrow = this->length();
+    }else{
+        assert(nrow > 0);
+    }
+    // Seed the generator
+    std::mt19937 eng(seed);
+    // Draw row indices from uniform distribution
+    std::uniform_int_distribution<> distr(0, this->length()-1);
+    // Create new empty DataFrame
+    DataFrame *new_frame = new DataFrame();
+    // pull random rows (as pointers, not copies) until full
+    while (new_frame->length() < nrow)
+    {
+        // get random row index with replacement
+        int rand_row = distr(eng);
+        // get pointer to that row in original dataframe and store in bootstrap
+        new_frame->addRow(this->row(rand_row));
+    }
     return *new_frame;
 }
 

--- a/src/datasets.cpp
+++ b/src/datasets.cpp
@@ -519,16 +519,16 @@ DataFrame DataFrame::sample(int nrow, int seed) const{
     // Draw row indices from uniform distribution
     std::uniform_int_distribution<> distr(0, this->length()-1);
     // Create new empty DataFrame
-    DataFrame *new_frame = new DataFrame();
+    DataFrame new_frame = DataFrame();
     // pull random rows (as pointers, not copies) until full
-    while (new_frame->length() < nrow)
+    while (new_frame.length() < nrow)
     {
         // get random row index with replacement
         int rand_row = distr(eng);
         // get pointer to that row in original dataframe and store in bootstrap
-        new_frame->addRow(this->row(rand_row));
+        new_frame.addRow(this->row(rand_row));
     }
-    return *new_frame;
+    return new_frame;
 }
 
 DataFrame DataFrame::transpose() const

--- a/src/datasets.hpp
+++ b/src/datasets.hpp
@@ -85,6 +85,7 @@ public:
     void addCol(DataVector *col);  // Append the values each row in the list (from pointer).
     void addCol(std::vector<double> vector);  // Append the values to each row in the list.
     DataFrame copy() const;  // Returns a copy of the DataFrame.
+    DataFrame sample(int nrow = -1, int seed = -1) const; // Samples
     DataFrame transpose() const;  // Returns a transposed copy of the DataFrame.
     std::vector<DataFrame*> split(int split_column, double split_threshold, bool equal_goes_left=true) const;  // Returns a pair of frames (value above and below threshold in specified column).
     std::string to_string(bool new_line=true, int col_width=9) const;  // Return the DataFrame as a string.

--- a/tests/test_datasets.cpp
+++ b/tests/test_datasets.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include "../src/datasets.cpp"
+#include <random>
 
 
 int main(){
@@ -70,4 +71,8 @@ int main(){
     std::cout << "Get mean along column axis:" << std::endl;
     std::cout << df_test.mean(1)->to_string();
 
+    // Bootstrap a sample and print, optionally specifying 5 rows and seed 1337
+    std::cout << "Bootstrap and print dataframe:" << std::endl;
+    DataFrame df_boot = df_test.sample(5, 1337);
+    df_boot.print(4);
 };


### PR DESCRIPTION
Bootstrap resampling with replacement. Can specify `nrow` and `seed`, but not whether or not to replace. Was thinking of making this method the de facto train/test splitter, but easier to just replicate the needed functionality in a dedicated method for that.

Requested @gpestre review to verify I am not needlessly making copies of data or messing with the underlying dataframes – or any other mistake I can't think of.