### PR TITLE
Prevent memory leaks.

### DIFF
--- a/src/datasets.cpp
+++ b/src/datasets.cpp
@@ -492,11 +492,20 @@ void DataFrame::addCol(std::vector<double> vector)
     this->addCol(col);
 }
 
-DataFrame DataFrame::copy() const
+DataFrame DataFrame::copy(bool deep) const
 {
-    /** Returns a copy of the DataFrame. */
-    DataFrame *new_frame = new DataFrame(this->matrix());
-    return *new_frame;
+    /** Returns a copy of the DataFrame. (If deep=true, also copies each row.) */
+    DataFrame new_frame;
+    if (deep){
+        new_frame = DataFrame(this->matrix());
+    } else {
+        new_frame = DataFrame();
+        for (int i = 0; i < this->length(); i++)
+        {
+            new_frame.addRow(this->row(i));
+        }
+    }
+    return new_frame;
 }
 
 DataFrame DataFrame::sample(int nrow, int seed) const{

--- a/src/datasets.cpp
+++ b/src/datasets.cpp
@@ -347,70 +347,70 @@ std::vector<std::vector<double>> DataFrame::matrix() const
     return matrix;
 }
 
-DataVector* DataFrame::min(bool axis) const
+DataVector DataFrame::min(bool axis) const
 {
     /**
      * Returns a vector of the min down columns (axis==0) or across rows (axis==1).
      * Returns a row if axis==0 and a column if axis==1.
      */
-    DataVector *result;
+    DataVector result;
     if (axis==0) {
-        result = new DataVector(true);  // is_row==true.
-        for (int i = 0; i < this->width(); i++) { result->addValue( this->col(i)->min() ); }
+        result = DataVector(true);  // is_row==true.
+        for (int i = 0; i < this->width(); i++) { result.addValue( this->col(i)->min() ); }
     } else {
-        result = new DataVector(false);  // is_row==false.
-        for (int i = 0; i < this->length(); i++) { result->addValue( this->row(i)->min() ); }
+        result = DataVector(false);  // is_row==false.
+        for (int i = 0; i < this->length(); i++) { result.addValue( this->row(i)->min() ); }
     }
     return result;
 }
 
-DataVector* DataFrame::max(bool axis) const
+DataVector DataFrame::max(bool axis) const
 {
     /**
      * Returns a vector of the max down columns (axis==0) or across rows (axis==1).
      * Returns a row if axis==0 and a column if axis==1.
      */
-    DataVector *result;
+    DataVector result;
     if (axis==0) {
-        result = new DataVector(true);  // is_row==true.
-        for (int i = 0; i < this->width(); i++) { result->addValue( this->col(i)->max() ); }
+        result = DataVector(true);  // is_row==true.
+        for (int i = 0; i < this->width(); i++) { result.addValue( this->col(i)->max() ); }
     } else {
-        result = new DataVector(false);  // is_row==false.
-        for (int i = 0; i < this->length(); i++) { result->addValue( this->row(i)->max() ); }
+        result = DataVector(false);  // is_row==false.
+        for (int i = 0; i < this->length(); i++) { result.addValue( this->row(i)->max() ); }
     }
     return result;
 }
 
-DataVector* DataFrame::sum(bool axis) const
+DataVector DataFrame::sum(bool axis) const
 {
     /**
      * Returns a vector of the means down columns (axis==0) or across rows (axis==1).
      * Returns a row if axis==0 and a column if axis==1.
      */
-    DataVector *result;
+    DataVector result;
     if (axis==0) {
-        result = new DataVector(true);  // is_row==true.
-        for (int i = 0; i < this->width(); i++) { result->addValue( this->col(i)->sum() ); }
+        result = DataVector(true);  // is_row==true.
+        for (int i = 0; i < this->width(); i++) { result.addValue( this->col(i)->sum() ); }
     } else {
-        result = new DataVector(false);  // is_row==false.
-        for (int i = 0; i < this->length(); i++) { result->addValue( this->row(i)->sum() ); }
+        result = DataVector(false);  // is_row==false.
+        for (int i = 0; i < this->length(); i++) { result.addValue( this->row(i)->sum() ); }
     }
     return result;
 }
 
-DataVector* DataFrame::mean(bool axis) const
+DataVector DataFrame::mean(bool axis) const
 {
     /**
      * Returns a vector of the means down columns (axis==0) or across rows (axis==1).
      * Returns a row if axis==0 and a column if axis==1.
      */
-    DataVector *result;
+    DataVector result;
     if (axis==0) {
-        result = new DataVector(true);  // is_row==true.
-        for (int i = 0; i < this->width(); i++) { result->addValue( this->col(i)->mean() ); }
+        result = DataVector(true);  // is_row==true.
+        for (int i = 0; i < this->width(); i++) { result.addValue( this->col(i)->mean() ); }
     } else {
-        result = new DataVector(false);  // is_row==false.
-        for (int i = 0; i < this->length(); i++) { result->addValue( this->row(i)->mean() ); }
+        result = DataVector(false);  // is_row==false.
+        for (int i = 0; i < this->length(); i++) { result.addValue( this->row(i)->mean() ); }
     }
     return result;
 }

--- a/src/datasets.cpp
+++ b/src/datasets.cpp
@@ -461,24 +461,24 @@ void DataFrame::addRow(std::vector<double> vector)
     this->addRow(row);
 }
 
-void DataFrame::addCol(DataVector *col)
+void DataFrame::addCol(DataVector col)
 {
     /** Append the values to each row in the list. */
     assert (!this->is_locked());
-    assert (!col->is_row());
-    assert (col->size()==this->length());
+    assert (!col.is_row());
+    assert (col.size()==this->length());
     if (this->rows_.size()==0)
     {
         // If this is the first column, set dimensions:
-        this->length_ = col->size();  // Width will be incremented below.
+        this->length_ = col.size();  // Width will be incremented below.
     } else {
         // Otherwise, make sure it matches existing dimension.
-        assert (col->size()==this->length());
+        assert (col.size()==this->length());
     }
     for (int i = 0; i < this->length(); i++)
     {
         assert (!this->rows_[i]->is_locked());
-        this->rows_[i]->addValue( col->value(i) );
+        this->rows_[i]->addValue( col.value(i) );
     }
     this->width_ += 1;
 }
@@ -487,7 +487,7 @@ void DataFrame::addCol(std::vector<double> vector)
 {
     /** Append the values to each row in the list. */
     // Create DataVector (column):
-    DataVector* col = new DataVector(vector,false);  // is_row==false.
+    DataVector col = DataVector(vector,false);  // is_row==false.
     // Add DataColumn to frame (and perform error-checking):
     this->addCol(col);
 }

--- a/src/datasets.cpp
+++ b/src/datasets.cpp
@@ -146,28 +146,28 @@ DataVector* DataVector::transpose() const
     return new_vector;
 }
 
-std::vector<DataVector*> DataVector::split(double split_threshold, bool equal_goes_left) const
+std::vector<DataVector> DataVector::split(double split_threshold, bool equal_goes_left) const
 {
     /**
      * Retrurns a pair of vectors (value above and below split_threshold).
      * Values equal to the threshold go left if equal_goes_left==true and right otherwise.
      */
-    DataVector* left = new DataVector(this->is_row());
-    DataVector* right = new DataVector(this->is_row());
+    DataVector left = DataVector(this->is_row());
+    DataVector right = DataVector(this->is_row());
     for (int i = 0; i < this->size(); i++)
     {
         double split_val = this->value(i);
         if (split_val<split_threshold) {
-            left->addValue(split_val);
+            left.addValue(split_val);
         } else if (split_val>split_threshold) {
-            right->addValue(split_val);
+            right.addValue(split_val);
         } else if (equal_goes_left) {
-            left->addValue(split_val);
+            left.addValue(split_val);
         } else if (!equal_goes_left) {
-            right->addValue(split_val);
+            right.addValue(split_val);
         }
     }
-    std::vector<DataVector*> results = { left, right };
+    std::vector<DataVector> results = { left, right };
     return results;
 }
 

--- a/src/datasets.cpp
+++ b/src/datasets.cpp
@@ -138,11 +138,11 @@ DataVector* DataVector::copy() const
     return new_vector;
 }
 
-DataVector* DataVector::transpose() const
+DataVector DataVector::transpose() const
 {
     /** Returns a pointer to a new vector that is the transpose of this one. */
     bool new_is_row = !this->is_row();
-    DataVector* new_vector = new DataVector(this->vector(),new_is_row);
+    DataVector new_vector = DataVector(this->vector(),new_is_row);
     return new_vector;
 }
 
@@ -547,7 +547,7 @@ DataFrame DataFrame::transpose() const
     // Get each column, transpose it, and add it as a row in new frame:
     for (int i = 0; i < this->width(); i++)
     {
-        new_frame.addRow( this->col(i)->transpose() );
+        new_frame.addRow(this->col(i)->transpose().vector());
     }
     return new_frame;
 }

--- a/src/datasets.cpp
+++ b/src/datasets.cpp
@@ -552,29 +552,29 @@ DataFrame DataFrame::transpose() const
     return new_frame;
 }
 
-std::vector<DataFrame*> DataFrame::split(int split_column, double split_threshold, bool equal_goes_left) const
+std::vector<DataFrame> DataFrame::split(int split_column, double split_threshold, bool equal_goes_left) const
 {
     /**
      * Returns a pair of tables (value above and below split_threshold in specified column).
      * Values equal to the threshold go left if equal_goes_left==true and right otherwise.
      */
-    DataFrame* left = new DataFrame();
-    DataFrame* right = new DataFrame();
+    DataFrame left = DataFrame();
+    DataFrame right = DataFrame();
     for (int i = 0; i < this->length(); i++)
     {
         DataVector* row = this->row(i);
         double split_val = row->value(split_column);
         if (split_val<split_threshold) {
-            left->addRow(row);
+            left.addRow(row);
         } else if (split_val>split_threshold) {
-            right->addRow(row);
+            right.addRow(row);
         } else if (equal_goes_left) {
-            left->addRow(row);
+            left.addRow(row);
         } else if (!equal_goes_left) {
-            right->addRow(row);
+            right.addRow(row);
         }
     }
-    std::vector<DataFrame*> results = { left, right };
+    std::vector<DataFrame> results = { left, right };
     return results;
 }
 

--- a/src/datasets.cpp
+++ b/src/datasets.cpp
@@ -543,13 +543,13 @@ DataFrame DataFrame::sample(int nrow, int seed) const{
 DataFrame DataFrame::transpose() const
 {
     /** Returns a new dataframe that is the transpose of this one. */
-    DataFrame *new_frame = new DataFrame();
+    DataFrame new_frame = DataFrame();
     // Get each column, transpose it, and add it as a row in new frame:
     for (int i = 0; i < this->width(); i++)
     {
-        new_frame->addRow( this->col(i)->transpose() );
+        new_frame.addRow( this->col(i)->transpose() );
     }
-    return *new_frame;
+    return new_frame;
 }
 
 std::vector<DataFrame*> DataFrame::split(int split_column, double split_threshold, bool equal_goes_left) const

--- a/src/datasets.cpp
+++ b/src/datasets.cpp
@@ -647,8 +647,7 @@ DataFrame::DataFrame(std::vector<std::vector<double>> matrix)
     for (int i = 0; i < matrix.size(); i++)
     {
         assert (matrix[i].size()==this->width());
-        DataVector* row = new DataVector(matrix[i],true);  // is_row==true.
-        this->addRow(row);
+        this->addRow(matrix[i]);
     }
 }
 

--- a/src/datasets.cpp
+++ b/src/datasets.cpp
@@ -130,11 +130,11 @@ void DataVector::addValue(double value)
     this->size_ += 1;
 }
 
-DataVector* DataVector::copy() const
+DataVector DataVector::copy() const
 {
     /** Returns a copy of the DataVector. */
     bool new_is_row = this->is_row();
-    DataVector* new_vector = new DataVector(this->vector(),new_is_row);
+    DataVector new_vector = DataVector(this->vector(),new_is_row);
     return new_vector;
 }
 

--- a/src/datasets.cpp
+++ b/src/datasets.cpp
@@ -305,10 +305,10 @@ DataVector* DataFrame::row(int r) const
     return this->rows_[ r ];
 }
 
-DataVector* DataFrame::col(int c) const
+DataVector DataFrame::col(int c) const
 {
     /** Get given column (constructed on the fly). */
-    DataVector* col = new DataVector(false);  // is_row==false.
+    DataVector col = DataVector(false);  // is_row==false.
     if (c>=0)
     {
         // Index from beginning (positive):
@@ -320,7 +320,7 @@ DataVector* DataFrame::col(int c) const
     }
     for (int i = 0; i < this->length(); i++)
     {
-        col->addValue( this->rows_[i]->value(c) );
+        col.addValue( this->rows_[i]->value(c) );
     }
     return col;
 }
@@ -356,7 +356,7 @@ DataVector DataFrame::min(bool axis) const
     DataVector result;
     if (axis==0) {
         result = DataVector(true);  // is_row==true.
-        for (int i = 0; i < this->width(); i++) { result.addValue( this->col(i)->min() ); }
+        for (int i = 0; i < this->width(); i++) { result.addValue( this->col(i).min() ); }
     } else {
         result = DataVector(false);  // is_row==false.
         for (int i = 0; i < this->length(); i++) { result.addValue( this->row(i)->min() ); }
@@ -373,7 +373,7 @@ DataVector DataFrame::max(bool axis) const
     DataVector result;
     if (axis==0) {
         result = DataVector(true);  // is_row==true.
-        for (int i = 0; i < this->width(); i++) { result.addValue( this->col(i)->max() ); }
+        for (int i = 0; i < this->width(); i++) { result.addValue( this->col(i).max() ); }
     } else {
         result = DataVector(false);  // is_row==false.
         for (int i = 0; i < this->length(); i++) { result.addValue( this->row(i)->max() ); }
@@ -390,7 +390,7 @@ DataVector DataFrame::sum(bool axis) const
     DataVector result;
     if (axis==0) {
         result = DataVector(true);  // is_row==true.
-        for (int i = 0; i < this->width(); i++) { result.addValue( this->col(i)->sum() ); }
+        for (int i = 0; i < this->width(); i++) { result.addValue( this->col(i).sum() ); }
     } else {
         result = DataVector(false);  // is_row==false.
         for (int i = 0; i < this->length(); i++) { result.addValue( this->row(i)->sum() ); }
@@ -407,7 +407,7 @@ DataVector DataFrame::mean(bool axis) const
     DataVector result;
     if (axis==0) {
         result = DataVector(true);  // is_row==true.
-        for (int i = 0; i < this->width(); i++) { result.addValue( this->col(i)->mean() ); }
+        for (int i = 0; i < this->width(); i++) { result.addValue( this->col(i).mean() ); }
     } else {
         result = DataVector(false);  // is_row==false.
         for (int i = 0; i < this->length(); i++) { result.addValue( this->row(i)->mean() ); }
@@ -547,7 +547,7 @@ DataFrame DataFrame::transpose() const
     // Get each column, transpose it, and add it as a row in new frame:
     for (int i = 0; i < this->width(); i++)
     {
-        new_frame.addRow(this->col(i)->transpose().vector());
+        new_frame.addRow(this->col(i).transpose().vector());
     }
     return new_frame;
 }

--- a/src/datasets.hpp
+++ b/src/datasets.hpp
@@ -73,10 +73,10 @@ public:
     DataVector* col(int c) const;  // Get pointerto given column (constructed on the fly).
     double value(int r, int c) const;  // Get value in given row and column.
     std::vector<std::vector<double>> matrix() const;  // Get a copy of values as a vector of vectors of doubles.
-    DataVector* min(bool axis=0) const;  // Returns a vector of the min down columns (axis==0) or across rows (axis==1).
-    DataVector* max(bool axis=0) const;  // Returns a vector of the max down columns (axis==0) or across rows (axis==1).
-    DataVector* sum(bool axis=0) const;  // Returns a vector of the means down columns (axis==0) or across rows (axis==1).
-    DataVector* mean(bool axis=0) const;  // Returns a vector of the means down columns (axis==0) or across rows (axis==1).
+    DataVector min(bool axis=0) const;  // Returns a vector of the min down columns (axis==0) or across rows (axis==1).
+    DataVector max(bool axis=0) const;  // Returns a vector of the max down columns (axis==0) or across rows (axis==1).
+    DataVector sum(bool axis=0) const;  // Returns a vector of the means down columns (axis==0) or across rows (axis==1).
+    DataVector mean(bool axis=0) const;  // Returns a vector of the means down columns (axis==0) or across rows (axis==1).
 
     // Utilities:
     void lock();  // Lock object to make it read-only.

--- a/src/datasets.hpp
+++ b/src/datasets.hpp
@@ -87,7 +87,7 @@ public:
     DataFrame sample(int nrow = -1, int seed = -1) const; // Samples
     DataFrame copy(bool deep=false) const;  // Returns a copy of the DataFrame.
     DataFrame transpose() const;  // Returns a transposed copy of the DataFrame.
-    std::vector<DataFrame*> split(int split_column, double split_threshold, bool equal_goes_left=true) const;  // Returns a pair of frames (value above and below threshold in specified column).
+    std::vector<DataFrame> split(int split_column, double split_threshold, bool equal_goes_left=true) const;  // Returns a pair of frames (value above and below threshold in specified column).
     std::string to_string(bool new_line=true, int col_width=9) const;  // Return the DataFrame as a string.
     void print(bool new_line=true, int col_width=9) const;  // Print the data frame.
 

--- a/src/datasets.hpp
+++ b/src/datasets.hpp
@@ -82,7 +82,7 @@ public:
     void lock();  // Lock object to make it read-only.
     void addRow(DataVector *row);  // Append to the list of rows (as pointer).
     void addRow(std::vector<double> vector);  // Wrap the values in a DataRow and add its pointer to the list.
-    void addCol(DataVector *col);  // Append the values each row in the list (from pointer).
+    void addCol(DataVector col);  // Append the values each row in the lists.
     void addCol(std::vector<double> vector);  // Append the values to each row in the list.
     DataFrame sample(int nrow = -1, int seed = -1) const; // Samples
     DataFrame copy(bool deep=false) const;  // Returns a copy of the DataFrame.

--- a/src/datasets.hpp
+++ b/src/datasets.hpp
@@ -34,7 +34,7 @@ public:
     // Utilities:
     void lock();  // Lock object to make it read-only.
     void addValue(double value);  // Add value to vector.
-    DataVector* copy() const;  // Returns a copy of the DataVector.
+    DataVector copy() const;  // Returns a copy of the DataVector.
     DataVector transpose() const;  // Returns a transposed copy of the DataVector.
     std::vector<DataVector> split(double split_threshold, bool equal_goes_left=true) const;  // Returns a pair of vectors (value above and below threshold).
     std::string to_string(bool new_line=true, int col_width=9) const;  // Return the DataVector as a string.

--- a/src/datasets.hpp
+++ b/src/datasets.hpp
@@ -36,7 +36,7 @@ public:
     void addValue(double value);  // Add value to vector.
     DataVector* copy() const;  // Returns a copy of the DataVector.
     DataVector* transpose() const;  // Returns a transposed copy of the DataVector.
-    std::vector<DataVector*> split(double split_threshold, bool equal_goes_left=true) const;  // Returns a pair of vectors (value above and below threshold).
+    std::vector<DataVector> split(double split_threshold, bool equal_goes_left=true) const;  // Returns a pair of vectors (value above and below threshold).
     std::string to_string(bool new_line=true, int col_width=9) const;  // Return the DataVector as a string.
     void print(bool new_line=true, int col_width=9) const;  // Print the data vector.
 

--- a/src/datasets.hpp
+++ b/src/datasets.hpp
@@ -70,7 +70,7 @@ public:
     int width() const;  // Returns number of columns.
     bool is_locked() const;  // Checks if object is read-only.
     DataVector* row(int r) const;  // Get pointer to given row (stored internally).
-    DataVector* col(int c) const;  // Get pointerto given column (constructed on the fly).
+    DataVector col(int c) const;  // Get given column (constructed on the fly).
     double value(int r, int c) const;  // Get value in given row and column.
     std::vector<std::vector<double>> matrix() const;  // Get a copy of values as a vector of vectors of doubles.
     DataVector min(bool axis=0) const;  // Returns a vector of the min down columns (axis==0) or across rows (axis==1).

--- a/src/datasets.hpp
+++ b/src/datasets.hpp
@@ -35,7 +35,7 @@ public:
     void lock();  // Lock object to make it read-only.
     void addValue(double value);  // Add value to vector.
     DataVector* copy() const;  // Returns a copy of the DataVector.
-    DataVector* transpose() const;  // Returns a transposed copy of the DataVector.
+    DataVector transpose() const;  // Returns a transposed copy of the DataVector.
     std::vector<DataVector> split(double split_threshold, bool equal_goes_left=true) const;  // Returns a pair of vectors (value above and below threshold).
     std::string to_string(bool new_line=true, int col_width=9) const;  // Return the DataVector as a string.
     void print(bool new_line=true, int col_width=9) const;  // Print the data vector.

--- a/src/datasets.hpp
+++ b/src/datasets.hpp
@@ -84,8 +84,8 @@ public:
     void addRow(std::vector<double> vector);  // Wrap the values in a DataRow and add its pointer to the list.
     void addCol(DataVector *col);  // Append the values each row in the list (from pointer).
     void addCol(std::vector<double> vector);  // Append the values to each row in the list.
-    DataFrame copy() const;  // Returns a copy of the DataFrame.
     DataFrame sample(int nrow = -1, int seed = -1) const; // Samples
+    DataFrame copy(bool deep=false) const;  // Returns a copy of the DataFrame.
     DataFrame transpose() const;  // Returns a transposed copy of the DataFrame.
     std::vector<DataFrame*> split(int split_column, double split_threshold, bool equal_goes_left=true) const;  // Returns a pair of frames (value above and below threshold in specified column).
     std::string to_string(bool new_line=true, int col_width=9) const;  // Return the DataFrame as a string.

--- a/src/decision_tree.cpp
+++ b/src/decision_tree.cpp
@@ -317,7 +317,7 @@ void DecisionTree::fit_(TreeNode* node)
 {
     DataFrame dataframe = node->getDataFrame();
     LabelCounter label_counter = LabelCounter(dataframe.col(-1));
-    double proportion = label_counter.get_values()->max()/label_counter.size();
+    double proportion = label_counter.get_values().max()/label_counter.size();
     if ( label_counter.size()==1 ) {
         return;  // Prune if there is only one class left.
     } else if ( dataframe.length()<2 ) {

--- a/src/decision_tree.cpp
+++ b/src/decision_tree.cpp
@@ -192,7 +192,7 @@ std::string DecisionTree::to_string() const
             if (this->isRegressionTree()){
                 // Regression tree:
                 out += "mean value: ";
-                out += std::to_string(node->getDataFrame().col(-1)->mean());
+                out += std::to_string(node->getDataFrame().col(-1).mean());
             } else {
                 // Classification tree:
                 out += "majority class: ";
@@ -285,7 +285,7 @@ std::pair<int,double> DecisionTree::findBestSplit(TreeNode *node) const
     // Explore possible splits:
     for (int i = 0; i < m; i++){
         col = shuf_inds[i];
-        std::vector<double> col_vals = dataframe.col(col)->vector();
+        std::vector<double> col_vals = dataframe.col(col).vector();
         // Remove duplicates:
         std::sort(col_vals.begin(), col_vals.end());
         col_vals.erase(std::unique(col_vals.begin(), col_vals.end()), col_vals.end());
@@ -385,7 +385,7 @@ double DecisionTree::predict_(DataVector* observation) const
     double prediction;
     if (this->isRegressionTree()) {
         // Regression tree: Predict mean of training data at terminal node:
-        prediction = node->getDataFrame().col(-1)->mean();
+        prediction = node->getDataFrame().col(-1).mean();
     } else {
         // Classification tree: Predict majority class of training data at terminal node:
         prediction = LabelCounter(node->getDataFrame().col(-1)).get_most_frequent();

--- a/src/decision_tree.cpp
+++ b/src/decision_tree.cpp
@@ -294,8 +294,8 @@ std::pair<int,double> DecisionTree::findBestSplit(TreeNode *node) const
             double val = col_vals[j];  // Don't split on last value (because it will produce empty `right`).
             // But splitting on first value works as <= means left won't be empty
             // Split dataset using current column and threshold, score, and update if best:
-            std::vector<DataFrame*> dataset_splits = dataframe.split(col, val, true); // equal_goes_left=true.
-            loss = this->calculateSplitLoss(dataset_splits[0],dataset_splits[1]);
+            std::vector<DataFrame> dataset_splits = dataframe.split(col, val, true); // equal_goes_left=true.
+            loss = this->calculateSplitLoss(&dataset_splits[0],&dataset_splits[1]);
             // std::cout << "    " << col << ", " << val << ", " << loss << std::endl;  // TEST
             if ((first_pass) or (loss<best_loss)){
                 first_pass = false;
@@ -338,16 +338,16 @@ void DecisionTree::fit_(TreeNode* node)
     node->setSplitFeature(split_feature);
     node->setSplitThreshold(split_threshold);
     // Calculate results of best split:
-    std::vector<DataFrame*> dataset_splits = dataframe.split(split_feature,split_threshold,true);  // equal_goes_left=true.
-    DataFrame *left_data = dataset_splits[0];
-    DataFrame *right_data = dataset_splits[1];
-    if ( (left_data->length()==0) or (right_data->length()==0) ) {
+    std::vector<DataFrame> dataset_splits = dataframe.split(split_feature,split_threshold,true);  // equal_goes_left=true.
+    DataFrame left_data = dataset_splits[0];
+    DataFrame right_data = dataset_splits[1];
+    if ( (left_data.length()==0) or (right_data.length()==0) ) {
         return;  // Prune if best split does not actually split the dataset.
     }
     // If split produces two non-empty dataframes, recurse to (new) children:
     this->num_leaves_ += 1;  // Each split causes net addition of 1 leaf.
-    TreeNode *left_child = new TreeNode(*left_data);
-    TreeNode *right_child = new TreeNode(*right_data);
+    TreeNode *left_child = new TreeNode(left_data);
+    TreeNode *right_child = new TreeNode(right_data);
     node->setLeft(left_child);
     node->setRight(right_child);
     // Recurse to (new) children:

--- a/src/decision_tree.cpp
+++ b/src/decision_tree.cpp
@@ -395,7 +395,7 @@ double DecisionTree::predict_(DataVector* observation) const
 DataVector DecisionTree::predict(DataFrame* testdata) const
 {
     /** Perform prediction sequentially on each observation and collect a vector of predictions. */
-    DataVector *predictions = new DataVector(false);  // is_row=false.
+    DataVector predictions = DataVector(false);  // is_row=false.
     // Make sure tree has been fitted before prediction:
     assert (this->isFitted());
     // Make sure dataframe has the correct number of features (or one extra column with labels).
@@ -404,9 +404,9 @@ DataVector DecisionTree::predict(DataFrame* testdata) const
     {
         DataVector* observation = testdata->row(i);
         double prediction = this->predict_(observation);
-        predictions->addValue(prediction);
+        predictions.addValue(prediction);
     }
-    return *predictions;
+    return predictions;
 }
 
 /*

--- a/src/losses.cpp
+++ b/src/losses.cpp
@@ -21,9 +21,9 @@ double LossFunction::misclassification_error(DataVector *labels)
     int prediction = label_counter.get_most_frequent();
     int correct = 0;
     int incorrect = 0;
-    for (int i = 0; i < labels->size(); i++)
+    for (int i = 0; i < labels.size(); i++)
     {
-        if (labels->value(i) == prediction) {
+        if (labels.value(i) == prediction) {
             correct += 1;
         } else {
             incorrect += 1;
@@ -38,22 +38,20 @@ double LossFunction::cross_entropy(DataVector *labels)
     /** Returns the loss calculated with cross_entropy. */
     double loss;
     LabelCounter label_counter = LabelCounter(labels);
-    int sum_of_counts = label_counter.get_values()->sum();  // Get total number of labels.
-    assert (sum_of_counts==labels->size());
+    int sum_of_counts = label_counter.get_values().sum();  // Get total number of labels.
+    assert (sum_of_counts==labels.size());
     int predicted_label = label_counter.get_most_frequent();
-    DataVector *labels_ = label_counter.get_labels();  // Get labels.
-    DataVector *counts_ = label_counter.get_values();  // Get count for each label.
+    DataVector labels_ = label_counter.get_labels();  // Get labels.
+    DataVector counts_ = label_counter.get_values();  // Get count for each label.
     double prop;  // Temporary variable to store proportion of current class.
-    for (int i = 0; i < counts_->size(); i++)
+    for (int i = 0; i < counts_.size(); i++)
     {
-        int label = labels_->value(i);
-        int count = counts_->value(i);
+        int label = labels_.value(i);
+        int count = counts_.value(i);
         prop = 1.0*count/sum_of_counts;
         loss += prop * std::log2(prop);
     }
     loss = -loss;  // Negate the sum.
-    delete labels_;
-    delete counts_;
     return loss;
 }
 
@@ -62,32 +60,31 @@ double LossFunction::gini_impurity(DataVector *labels)
     /** Returns the loss calculated with gini_impurity. */
     double loss = 0;
     LabelCounter label_counter = LabelCounter(labels);
-    int sum_of_counts = label_counter.get_values()->sum();  // Get total number of labels.
-    assert (sum_of_counts==labels->size());
+    int sum_of_counts = label_counter.get_values().sum();  // Get total number of labels.
+    assert (sum_of_counts==labels.size());
     //int predicted_label = label_counter.get_most_frequent();
-    DataVector *counts_ = label_counter.get_values();  // Get count for each label (don't actually need the label).
+    DataVector counts_ = label_counter.get_values();  // Get count for each label (don't actually need the label).
     double prop;  // Temporary variable to store proportion of current class.
-    for (int i = 0; i < counts_->size(); i++)
+    for (int i = 0; i < counts_.size(); i++)
     {
-        prop = 1.0*counts_->value(i)/sum_of_counts;
+        prop = 1.0*counts_.value(i)/sum_of_counts;
         loss += prop*(1-prop);
     }
-    delete counts_;
     return loss;
 }
 
 double LossFunction::mean_squared_error(DataVector *labels)
 {
     /** Returns the mean squared error of a set of labels, assuming most common is used as prediction. */
-    double prediction = labels->mean();
+    double prediction = labels.mean();
     double loss = 0;
     double error;
-    for (int i = 0; i < labels->size(); i++)
+    for (int i = 0; i < labels.size(); i++)
     {
-        error = ( labels->value(i) - prediction );
+        error = ( labels.value(i) - prediction );
         loss += (error*error);
     }
-    loss = 1.0*loss/labels->size();
+    loss = 1.0*loss/labels.size();
     return loss;
 }
 
@@ -111,7 +108,7 @@ std::string LossFunction::method()
 
 double LossFunction::calculate(DataVector *labels)
 {
-    assert (labels->size()>0);  // Loss is undefined for empty list.
+    assert (labels.size()>0);  // Loss is undefined for empty list.
     double loss;
     if (this->method_=="misclassification_error") {
         loss = this->misclassification_error(labels);
@@ -218,30 +215,30 @@ double LabelCounter::get_most_frequent() const
     return most_freq_key;
 }
 
-DataVector* LabelCounter::get_labels() const
+DataVector LabelCounter::get_labels() const
 {
     /** Get DataVector of labels. */
-    DataVector *labels = new DataVector(false);  // is_row==false.
+    DataVector labels = DataVector(false);  // is_row==false.
     std::map<int, int>::const_iterator it = this->counts_.begin();
     while (it != this->counts_.end())
     {
         int key = it->first;
         // int value = it->second;
-        labels->addValue(key);
+        labels.addValue(key);
         it++;
     }
     return labels;
 }
-DataVector* LabelCounter::get_values() const
+DataVector LabelCounter::get_values() const
 {
     /** Get DataVector of values. */
-    DataVector *values = new DataVector(false);  // is_row==false.
+    DataVector values = DataVector(false);  // is_row==false.
     std::map<int, int>::const_iterator it = this->counts_.begin();
     while (it != this->counts_.end())
     {
         // int key = it->first;
         int value = it->second;
-        values->addValue(value);
+        values.addValue(value);
         it++;
     }
     return values;
@@ -364,5 +361,5 @@ LabelCounter::LabelCounter(DataVector *labels)
 {
     /** Initialize counter from given vector (pointer). */
     this->total_size_ = 0;
-    this->increment(labels);
+    this->increment(*labels);
 }

--- a/src/losses.cpp
+++ b/src/losses.cpp
@@ -13,7 +13,7 @@
  */
 
 
-double LossFunction::misclassification_error(DataVector *labels)
+double LossFunction::misclassification_error(DataVector labels)
 {
     /** Returns the loss calculated with misclassification_error. */
     double loss;
@@ -33,7 +33,7 @@ double LossFunction::misclassification_error(DataVector *labels)
     return loss;
 }
 
-double LossFunction::cross_entropy(DataVector *labels)
+double LossFunction::cross_entropy(DataVector labels)
 {
     /** Returns the loss calculated with cross_entropy. */
     double loss;
@@ -55,7 +55,7 @@ double LossFunction::cross_entropy(DataVector *labels)
     return loss;
 }
 
-double LossFunction::gini_impurity(DataVector *labels)
+double LossFunction::gini_impurity(DataVector labels)
 {
     /** Returns the loss calculated with gini_impurity. */
     double loss = 0;
@@ -73,7 +73,7 @@ double LossFunction::gini_impurity(DataVector *labels)
     return loss;
 }
 
-double LossFunction::mean_squared_error(DataVector *labels)
+double LossFunction::mean_squared_error(DataVector labels)
 {
     /** Returns the mean squared error of a set of labels, assuming most common is used as prediction. */
     double prediction = labels.mean();
@@ -106,7 +106,7 @@ std::string LossFunction::method()
  */
 
 
-double LossFunction::calculate(DataVector *labels)
+double LossFunction::calculate(DataVector labels)
 {
     assert (labels.size()>0);  // Loss is undefined for empty list.
     double loss;
@@ -122,9 +122,9 @@ double LossFunction::calculate(DataVector *labels)
     return loss;
 }
 
-double LossFunction::calculate(DataVector labels)
+double LossFunction::calculate(DataVector *labels)
 {
-    return this->calculate(&labels);
+    return this->calculate(*labels);
 }
 
 
@@ -312,10 +312,7 @@ void LabelCounter::increment(DataVector labels)
 void LabelCounter::increment(DataVector *labels)
 {
     /** Increment counter for a vector (pointer) of labels. */
-    for (int i = 0; i < labels->size(); i++)
-    {
-        this->increment( labels->value(i) );
-    }
+    this->increment( *labels );
 }
 
 

--- a/src/losses.hpp
+++ b/src/losses.hpp
@@ -62,8 +62,8 @@ public:
     bool has_label(double label) const;  // Check if a label has been counted.
     int get_count(double label) const;  // Get counter value for specified label (coerced to integer).
     double get_most_frequent() const;  // Get most common label (breaking ties in favor of smallest label).
-    DataVector* get_labels() const;  // Get DataVector of labels.
-    DataVector* get_values() const;  // Get DataVector of values.
+    DataVector get_labels() const;  // Get DataVector of labels.
+    DataVector get_values() const;  // Get DataVector of values.
     std::string to_string() const;  // Represent LabelCounter as string.
     void print() const;  // Print LabelCounter to standard output.
 

--- a/src/losses.hpp
+++ b/src/losses.hpp
@@ -17,10 +17,10 @@ private:
     std::string method_;  // The loss type.
 
     // Utilities:
-    double misclassification_error(DataVector *labels);
-    double cross_entropy(DataVector *labels);
-    double gini_impurity(DataVector *labels);
-    double mean_squared_error(DataVector *labels);
+    double misclassification_error(DataVector labels);
+    double cross_entropy(DataVector labels);
+    double gini_impurity(DataVector labels);
+    double mean_squared_error(DataVector labels);
 
 public:
 
@@ -28,8 +28,8 @@ public:
     std::string method();
 
     // Utilities:
-    double calculate(DataVector *labels);
     double calculate(DataVector labels);
+    double calculate(DataVector *labels);
 
     // Overloaded operators:
 

--- a/tests/test_datasets.cpp
+++ b/tests/test_datasets.cpp
@@ -55,21 +55,21 @@ int main(){
     
     // Test min, max, sum, mean:
     std::cout << "Get min along row axis:" << std::endl;
-    std::cout << df_test.min(0)->to_string();
+    std::cout << df_test.min(0).to_string();
     std::cout << "Get min along column axis:" << std::endl;
-    std::cout << df_test.min(1)->to_string();
+    std::cout << df_test.min(1).to_string();
     std::cout << "Get max along row axis:" << std::endl;
-    std::cout << df_test.max(0)->to_string();
+    std::cout << df_test.max(0).to_string();
     std::cout << "Get max along column axis:" << std::endl;
-    std::cout << df_test.max(1)->to_string();
+    std::cout << df_test.max(1).to_string();
     std::cout << "Get sum along row axis:" << std::endl;
-    std::cout << df_test.sum(0)->to_string();
+    std::cout << df_test.sum(0).to_string();
     std::cout << "Get sum along column axis:" << std::endl;
-    std::cout << df_test.sum(1)->to_string();
+    std::cout << df_test.sum(1).to_string();
     std::cout << "Get mean along row axis:" << std::endl;
-    std::cout << df_test.mean(0)->to_string();
+    std::cout << df_test.mean(0).to_string();
     std::cout << "Get mean along column axis:" << std::endl;
-    std::cout << df_test.mean(1)->to_string();
+    std::cout << df_test.mean(1).to_string();
 
     // Bootstrap a sample and print, optionally specifying 5 rows and seed 1337
     std::cout << "Bootstrap and print dataframe:" << std::endl;

--- a/tests/test_datasets.cpp
+++ b/tests/test_datasets.cpp
@@ -43,9 +43,9 @@ int main(){
     
     // Test splitting by threshold (vector):
     std::cout << "Split last column with threshold 0.5 (transposed for better printing):" << std::endl;
-    std::vector<DataVector*> test_split_vector = df_test.col(-1)->split(0.5);
-    std::cout << "L: " << *test_split_vector[0]->transpose() << std::endl;
-    std::cout << "R: " << *test_split_vector[1]->transpose() << std::endl;
+    std::vector<DataVector> test_split_vector = df_test.col(-1)->split(0.5);
+    std::cout << "L: " << test_split_vector[0].transpose() << std::endl;
+    std::cout << "R: " << test_split_vector[1].transpose() << std::endl;
     
     // Test splitting by threshold (table):
     std::cout << "Split table on first column with threshold 3.396562:" << std::endl;

--- a/tests/test_datasets.cpp
+++ b/tests/test_datasets.cpp
@@ -28,8 +28,8 @@ int main(){
     
     // Get transpose of first column:
     std::cout << "Print transpose of first column:" << std::endl;
-    DataVector* test_transpose_col = df_test.col(0)->transpose();
-    std::cout << *test_transpose_col << std::endl;
+    DataVector test_transpose_col = df_test.col(0)->transpose();
+    std::cout << test_transpose_col << std::endl;
     
     // Get copy of data frame:
     std::cout << "Print copy of data frame:" << std::endl;

--- a/tests/test_datasets.cpp
+++ b/tests/test_datasets.cpp
@@ -23,8 +23,8 @@ int main(){
 
     // Get copy of last column:
     std::cout << "Print last column:" << std::endl;
-    DataVector* test_col = df_test.col(-1)->copy();
-    std::cout << *test_col << std::endl;
+    DataVector test_col = df_test.col(-1)->copy();
+    std::cout << test_col << std::endl;
     
     // Get transpose of first column:
     std::cout << "Print transpose of first column:" << std::endl;

--- a/tests/test_datasets.cpp
+++ b/tests/test_datasets.cpp
@@ -49,9 +49,9 @@ int main(){
     
     // Test splitting by threshold (table):
     std::cout << "Split table on first column with threshold 3.396562:" << std::endl;
-    std::vector<DataFrame*> test_split_table = df_test.split(0,3.396562,false);
-    std::cout << "L:\n" << *test_split_table[0] << std::endl;
-    std::cout << "R:\n" << *test_split_table[1] << std::endl;
+    std::vector<DataFrame> test_split_table = df_test.split(0,3.396562,false);
+    std::cout << "L:\n" << test_split_table[0] << std::endl;
+    std::cout << "R:\n" << test_split_table[1] << std::endl;
     
     // Test min, max, sum, mean:
     std::cout << "Get min along row axis:" << std::endl;

--- a/tests/test_datasets.cpp
+++ b/tests/test_datasets.cpp
@@ -23,12 +23,12 @@ int main(){
 
     // Get copy of last column:
     std::cout << "Print last column:" << std::endl;
-    DataVector test_col = df_test.col(-1)->copy();
+    DataVector test_col = df_test.col(-1).copy();
     std::cout << test_col << std::endl;
     
     // Get transpose of first column:
     std::cout << "Print transpose of first column:" << std::endl;
-    DataVector test_transpose_col = df_test.col(0)->transpose();
+    DataVector test_transpose_col = df_test.col(0).transpose();
     std::cout << test_transpose_col << std::endl;
     
     // Get copy of data frame:
@@ -43,7 +43,7 @@ int main(){
     
     // Test splitting by threshold (vector):
     std::cout << "Split last column with threshold 0.5 (transposed for better printing):" << std::endl;
-    std::vector<DataVector> test_split_vector = df_test.col(-1)->split(0.5);
+    std::vector<DataVector> test_split_vector = df_test.col(-1).split(0.5);
     std::cout << "L: " << test_split_vector[0].transpose() << std::endl;
     std::cout << "R: " << test_split_vector[1].transpose() << std::endl;
     

--- a/tests/test_decision_tree.cpp
+++ b/tests/test_decision_tree.cpp
@@ -51,7 +51,7 @@ int main(){
     }
     
     std::cout << "Perform prediction on new data." << std::endl;
-    DataFrame *test_data = new DataFrame({
+    DataFrame test_data = DataFrame({
         {2.0, 0.0, 3.0},  // Expected: 1.
         {2.0, 1.0, 3.0},  // Expected: 1.
         {2.0, 2.0, 3.0},  // Expected: 1.
@@ -64,8 +64,7 @@ int main(){
         {7.0, 1.0, 3.0},  // Expected: 4.
         {7.0, 2.0, 3.0},  // Expected: 4.
     });
-    DataVector test_predictions = classification_tree.predict(test_data);
-    delete test_data;  // Remove dataframe from heap.
+    DataVector test_predictions = classification_tree.predict(&test_data);
     std::cout << "Predictions :" << std::endl;
     std::cout << test_predictions << std::endl;
 

--- a/tests/test_losses.cpp
+++ b/tests/test_losses.cpp
@@ -16,8 +16,8 @@ int main(){
     std::cout << "Counts: " << label_counter1 << std::endl;
     std::cout << "Most frequent key: " << label_counter1.get_most_frequent() << std::endl;
     std::cout << std::endl;
-    std::cout << "Labels: " + label_counter1.get_labels()->transpose()->to_string(false);
-    std::cout << "Values: " + label_counter1.get_values()->transpose()->to_string(false);
+    std::cout << "Labels: " + label_counter1.get_labels()->transpose().to_string(false);
+    std::cout << "Values: " + label_counter1.get_values()->transpose().to_string(false);
     std::cout << "Counts: " << label_counter1 << std::endl;
     std::cout << std::endl;
 

--- a/tests/test_losses.cpp
+++ b/tests/test_losses.cpp
@@ -16,8 +16,8 @@ int main(){
     std::cout << "Counts: " << label_counter1 << std::endl;
     std::cout << "Most frequent key: " << label_counter1.get_most_frequent() << std::endl;
     std::cout << std::endl;
-    std::cout << "Labels: " + label_counter1.get_labels()->transpose().to_string(false);
-    std::cout << "Values: " + label_counter1.get_values()->transpose().to_string(false);
+    std::cout << "Labels: " + label_counter1.get_labels().transpose().to_string(false);
+    std::cout << "Values: " + label_counter1.get_values().transpose().to_string(false);
     std::cout << "Counts: " << label_counter1 << std::endl;
     std::cout << std::endl;
 


### PR DESCRIPTION
- Remove as many `new` keywords as possible to prevent memory leaks.
- In some cases, change API to take in objects instead of pointers (either to require more caution from user about memory management or to make it possible/easier to avoid a `new` keyword).

In most of these cases, the objects being passed are small/temporary, so I don't think there was too much benefit from passing them as pointers rather than objects in the previous approach.

The most salient case is the `DataFrame.col` method:
- Before the rewrite, it was creating a new copy of the column on the memory heap every time we used it to access a column of values (even if we were just using it for read-only purposes).
- It now creates a column in the stack and returns it as an object. If the calling function simply reads values from it and doesn't store it, the column object gets wiped from the stack after use (which is desirable in this case, from a memory management perspective); if it does need to be conserved, the user has to make that happen explicitly (which helps prevent us from accidentally saving copies indefinitely and wasting memory).