### PR TITLE
Fix cross-platform RF fitting

### DIFF
--- a/demo/demo_rf_serial.cpp
+++ b/demo/demo_rf_serial.cpp
@@ -18,15 +18,12 @@ int main(){
     // Extract targets
     DataVector targets = df_sonar.col(-1);
     std::cout << "Targets size: " << targets.size() << std::endl;
-    std::cout << targets << std::endl;
 
     // Fit RF on full dataset and verify accuracy is high on seen data
     std::cout << "Build and fit RandomForest binary classifier on Sonar" << std::endl;
 
     RandomForest rf1 = RandomForest(df_sonar,ntree,false,"gini_impurity",-1,-1,-1,-1,-1,1337);
     rf1.fit();
-
-    std::cout << "Tree fitted: " << rf1.isFitted() << std::endl;
 
     DataVector preds = rf1.predict(&df_sonar);
     std::cout << "Predictions size: " << preds.size() << std::endl;

--- a/src/random_forest.cpp
+++ b/src/random_forest.cpp
@@ -115,7 +115,7 @@ void RandomForest::fit()
 {
     /** Fit RandomForest with given parameters. */
     this->trees_ = {};
-    for (int i; i < this->num_trees_; i++)
+    for (int i = 0; i < this->num_trees_; i++)
     {
         int data_seed = this->seed_gen.new_seed();
         int tree_seed = this->seed_gen.new_seed();


### PR DESCRIPTION
Fix that `RandomForest` fit worked as intended on Gabe's Windows, but not Will or Johannes' Macs. This took some serious engineering to fix, as the file changes clearly show.

This surely boils down to a difference in C++ and/or compiler versions, I'd think.