### PR TITLE
updating random_forest for OpenMP repeatability

### DIFF
--- a/speedup/rf_openmp.cpp
+++ b/speedup/rf_openmp.cpp
@@ -18,7 +18,7 @@ int main(){
     DataFrame df_test = train_and_test[1];
 
     // Fit RF on train and evalute on test, with lower accuracy
-    RandomForest rf2 = RandomForest(df_train,ntree,false,"gini_impurity",-1,-1,-1,3,-1,42);
+    RandomForest rf2 = RandomForest(df_train,ntree,false,"gini_impurity",-1,-1,-1,3,-1,69);
 
     std::cout << "Accuracy train: " << accuracy(df_train.col(-1), rf2.predict(&df_train)) << std::endl;
     std::cout << "Accuracy test:  " << accuracy(df_test.col(-1), rf2.predict(&df_test)) << std::endl;


### PR DESCRIPTION
There isn't a way to implement repeatability in our construction of the seed. There are pragma directives for executing certain parts of the code in sequence but doing that limits speedup. I created a vector of seeds before parallelization to give us the behavior we want.

Couple other points:
- Having said that, there seems to be another source of randomness elsewhere. For certain master seed values, the results accuracy score jumps around between 2-3 values. This may be due to splitting happening randomly at a node where multiple splits give the same scores.
- Running the script multiple times in quick succession started giving out-of-memory errors. Perhaps we should be deleting some data from memory after each run? Not a huge deal, but @gpestre might have ideas.