### PR TITLE
OpenMP parallelise mostly everything

### DIFF
--- a/src-openmp/datasets.cpp
+++ b/src-openmp/datasets.cpp
@@ -527,11 +527,14 @@ DataFrame DataFrame::sample(int nrow, int seed, bool replace) const{
         // Draw row indices from uniform distribution
         std::uniform_int_distribution<> distr(0, this->length()-1);
         // pull random rows (as pointers, not copies) with replacement until full
-        while (new_frame.length() < nrow){
-            // get random row index with replacement
-            int rand_row = distr(eng);
-            // get pointer to that row in original dataframe and store in bootstrap
-            new_frame.addRow(this->row(rand_row));
+        #pragma omp parallel shared(new_frame)
+        {
+            while (new_frame.length() < nrow){
+                // get random row index with replacement
+                int rand_row = distr(eng);
+                // get pointer to that row in original dataframe and store in bootstrap
+                new_frame.addRow(this->row(rand_row));
+            }
         }
     }else{
         // pre-allocate vector of row indices

--- a/src-openmp/decision_tree.cpp
+++ b/src-openmp/decision_tree.cpp
@@ -384,7 +384,6 @@ double DecisionTree::predict_(DataVector* observation) const
 DataVector DecisionTree::predict(DataFrame* testdata) const
 {
     /** Perform prediction sequentially on each observation and collect a vector of predictions. */
-    //DataVector predictions = DataVector(false);  // is_row=false.
     int n = testdata->length();
     std::vector<double> preds(n, -1);
     // Make sure tree has been fitted before prediction:
@@ -400,7 +399,6 @@ DataVector DecisionTree::predict(DataFrame* testdata) const
         {
             DataVector* observation = testdata->row(i);
             double prediction = this->predict_(observation);
-            //predictions.addValue(prediction);
             preds[i] = prediction;
         }
     }

--- a/src-openmp/decision_tree.cpp
+++ b/src-openmp/decision_tree.cpp
@@ -277,46 +277,42 @@ std::pair<int,double> DecisionTree::findBestSplit(TreeNode *node)
             std::swap(shuf_inds[i], shuf_inds[i+(std::rand() % (this->num_features_-i))]);
         }
     }
-    // Initialize temporary variables:
-    bool first_pass = true;
-    int best_column, col;
-    double best_threshold, best_loss, loss;
-
+    // Can't pre-allocate since we don't know the number of unique values per column
+    std::vector<double> losses;
+    std::vector<std::pair<int, double>> cols_splits;
     // Explore possible splits:
     for (int i = 0; i < this->mtry_; i++){
-        col = shuf_inds[i];
+        int col = shuf_inds[i];
         std::vector<double> col_vals = dataframe.col(col).vector();
         // Remove duplicates:
         std::sort(col_vals.begin(), col_vals.end());
         col_vals.erase(std::unique(col_vals.begin(), col_vals.end()), col_vals.end());
-
         int j;
-        double val;
-        std::vector<DataFrame> dataset_splits;
-        #pragma omp parallel shared(col_vals, first_pass, best_column, best_threshold, best_loss) private(j, dataset_splits, loss)
+        #pragma omp parallel shared(losses, cols_splits, col) private(j)
         {        
             // For each unique column value, try that col and val as split, get score:
             #pragma omp for schedule(dynamic)
             for (j = 0; j < col_vals.size()-1; j++){
                 // Don't split on last value (because it will produce empty `right`).
-                //double val = col_vals[j];
-                val = col_vals[j];
+                double val = col_vals[j];
                 // But splitting on first value works as <= means left won't be empty
                 // Split dataset using current column and threshold, score, and update if best:
                 // equal_goes_left=true.
-                dataset_splits = dataframe.split(col, val, true);
-                loss = this->calculateSplitLoss(&dataset_splits[0], &dataset_splits[1]);
-                if ((first_pass) or (loss<best_loss)){
-                    first_pass = false;
-                    best_column = col;
-                    best_threshold = val;
-                    best_loss = loss;
-                }
+                std::vector<DataFrame> dataset_splits = dataframe.split(col, val, true);
+                double loss = this->calculateSplitLoss(&dataset_splits[0], &dataset_splits[1]);
+                losses.push_back(loss);
+                cols_splits.push_back(std::make_pair(col, val));
             }
         }
     }
-    // Placeholder value should have been replaced.
-    assert (best_column!=-1);
+    int best_column;
+    double best_threshold;
+    // Find lowest loss combination and return it
+    int ind_min = std::min_element(losses.begin(), losses.end()) - losses.begin();
+    best_column = cols_splits[ind_min].first;
+    best_threshold = cols_splits[ind_min].second;
+    // Sanity check that function did something
+    assert(best_column >= 0);
     split = std::make_pair(best_column, best_threshold);
     return split;
 }

--- a/src-openmp/random_forest.cpp
+++ b/src-openmp/random_forest.cpp
@@ -121,17 +121,14 @@ void RandomForest::fit_()
     /** Fit RandomForest with given parameters. */
     this->trees_ = {};
     int i;
-
     // Initialize vectors with seed values
     std::vector<int> data_seed_vector;
     std::vector<int> tree_seed_vector;
-
     // Pre-fill vectors with seed values
     for(int j=0; j < this->num_trees_; j++){
         data_seed_vector.push_back(this->seed_gen.new_seed());
         tree_seed_vector.push_back(this->seed_gen.new_seed());
     }
-
     // Create a team of threads for parallel execution
     #pragma omp parallel shared(data_seed_vector, tree_seed_vector) private(i)
     {
@@ -139,7 +136,6 @@ void RandomForest::fit_()
             int nthreads = (int)omp_get_num_threads();
             std::cout << "nthreads: " << nthreads << std::endl;
         }
-
         // Execute for loop in parallel
         #pragma omp for schedule(dynamic)
         for (i = 0; i < this->num_trees_; i++){


### PR DESCRIPTION
Add OpenMP pragmas to `DecisionTree.predict()`, `DecisionTree.findBestSplit()`, `RandomForest.fit()`, and `DataFrame.sample()`.

After compiling and running `speedup/rf_openmp.cpp` it will fail every now and then due to bad `malloc` requests. This is due to OpenMP and likely caused by something deep down in our code. It happens rarely and simply requires re-running or, at worst, recompiling then re-running.